### PR TITLE
Fix 4.2.1.6 rsyslog modload

### DIFF
--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -549,7 +549,7 @@
             regexp: "{{ item.regexp }}"
             line: "{{ item.line }}"
         with_items:
-            - { regexp: '^\$ModLoad|^#\$ModLoad', line: '$ModLoad imtc' }
+            - { regexp: '^\$ModLoad|^#\$ModLoad', line: '$ModLoad imtcp' }
             - { regexp: '^\$InputTCPServerRun|^#\$InputTCPServerRun', line: '$InputTCPServerRun 514' }
         notify: restart rsyslog
         when: ubtu18cis_system_is_log_server


### PR DESCRIPTION
The correct module name is imtcp, not imtc