### PR TITLE
Only chown interactive users' home directories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -616,6 +616,12 @@ ubtu18cis_no_group_adjust: true
 # Set to true this role will remove that bit, set to false we will just warn about the files
 ubtu18cis_suid_adjust: false
 
+# Control 6.2.5
+# Interactive users must own their own home directories. All users with uid
+# greater than or equal to this value will be considered interactive, and we
+# will ensure that they are the owners of their own homedirs.
+ubtu18cis_int_gid: 1000
+
 # Control 6.2.7
 # This control toggles automation to set all users dot files to not group or world writable
 # Value of true will change file permissiosn, value of false will skip the automation changing permissions. 

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -137,6 +137,7 @@
       label: "{{ ubtu18cis_passwd_label }}"
   when:
       - ubtu18cis_rule_6_2_5
+      - item.uid >= ubtu18cis_int_gid
   tags:
       - level1-server
       - level1-workstation


### PR DESCRIPTION
Taken by example from ansible-lockdown/RHEL8-CIS, where this same fix is
implemented.

Fixes #59.