### PR TITLE
Update rule in ubtu18cis_4_1_15_actions.rules.j2

### DIFF
--- a/templates/audit/ubtu18cis_4_1_15_actions.rules.j2
+++ b/templates/audit/ubtu18cis_4_1_15_actions.rules.j2
@@ -1,5 +1,5 @@
--a always,exit -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
 {% if ansible_architecture == 'x86_64' -%}
--a always,exit -F arch=b64 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
 {% endif %}
 


### PR DESCRIPTION
**Overall Review of Changes:**
Space needed between '-F' and `auid`.

This matches what UBUNTU18-CIS-Audit is expecting too.

`-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions`

vs

`-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions`

**Issue Fixes:**

N/A

**Enhancements:**

`4.1.15 | L2 | Ensure system administrator command executions (sudo) are collected | Config` will not be listed as unsuccessful in the Post Audit report.

**How has this been tested?:**

Post audit report:

```
            "successful": true,
            "summary-line": "Command: auditd_sudolog_live: stdout: matches expectation: [-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F auid\u003e=1000 -F auid!=-1 -F key=actions -a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F auid\u003e=1000 -F auid!=-1 -F key=actions]",
            "test-type": 2,
            "title": "4.1.15 | L2 | Ensure system administrator command executions (sudo) are collected | Live"
```

Signed-off-by: Hank Szeto <szeto@thinkingcap.com.au>


