### PR TITLE
fixes ufw typo in 3.5.1.5

### DIFF
--- a/tasks/section_3/cis_3.5.x.yml
+++ b/tasks/section_3/cis_3.5.x.yml
@@ -105,7 +105,7 @@
 
       - name: "3.5.1.5 | PATCH | Ensure outbound connections are configured | Allow all"
         community.general.ufw:
-            default: allow
+            rule: allow
             direction: outgoing
         notify: reload ufw
         when: "'all' in ubtu18cis_ufw_allow_out_ports"


### PR DESCRIPTION
**Overall Review of Changes:**
Found a typo in rule 3.5.1.5

**Issue Fixes:**
says default: but should be a rule: to allow outbound

**Enhancements:**
n/a
**How has this been tested?:**
tested locally
